### PR TITLE
패키지 구조 | 도메인 및 엔티티 생성 | 채팅 API 구현

### DIFF
--- a/src/main/java/com/network/sse/SseApplication.java
+++ b/src/main/java/com/network/sse/SseApplication.java
@@ -2,8 +2,10 @@ package com.network.sse;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class SseApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/network/sse/chat_message/controller/ChatMessageController.java
+++ b/src/main/java/com/network/sse/chat_message/controller/ChatMessageController.java
@@ -1,0 +1,43 @@
+package com.network.sse.chat_message.controller;
+
+import com.network.sse.chat_message.domain.ChatMessage;
+import com.network.sse.chat_message.domain.dto.PostSendChatMessage;
+import com.network.sse.chat_message.service.ChatMessageService;
+import com.network.sse.common.domain.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("chat-message")
+@RequiredArgsConstructor
+public class ChatMessageController {
+    private final ChatMessageService chatMessageService;
+
+    /*메시지 전송*/
+    @PostMapping("")
+    public BaseResponse<String> sendChatMessage(
+            @RequestBody PostSendChatMessage postSendChatMessage
+            ) {
+        // 채팅 메시지 객체 생성 및 저장
+        ChatMessage chatMessage = chatMessageService.saveChatMessage(postSendChatMessage);
+
+        return new BaseResponse<>("요청에 성공하였습니다.", HttpStatus.OK.value(), chatMessage.getId()+"번의 메시지가 전송되었습니다.");
+    }
+
+    /*특정 메시지 조회*/
+    @GetMapping("/{message-id}")
+    public BaseResponse<String> getChatMessage(
+            @PathVariable(name = "message-id")
+            long messageId
+    ) {
+        ChatMessage chatMessage = chatMessageService.getChatMessage(messageId);
+
+        return new BaseResponse<>("요청에 성공하였습니다.", HttpStatus.OK.value(), chatMessage.getContent());
+    }
+}

--- a/src/main/java/com/network/sse/chat_message/domain/ChatMessage.java
+++ b/src/main/java/com/network/sse/chat_message/domain/ChatMessage.java
@@ -1,0 +1,35 @@
+package com.network.sse.chat_message.domain;
+
+import com.network.sse.chat_room.domain.ChatRoom;
+import com.network.sse.common.domain.Base;
+import com.network.sse.user.domain.User;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ChatMessage extends Base {
+    private Long id;
+    private ChatRoom chatRoom;
+    private User sender;
+    private User receiver;
+    private String content;
+    private boolean isRemoved;
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public ChatMessage(Long id, ChatRoom chatRoom, User sender, User receiver, String content, boolean isRemoved, LocalDateTime deletedAt) {
+        this.id = id;
+        this.chatRoom = chatRoom;
+        this.sender = sender;
+        this.receiver = receiver;
+        this.content = content;
+        this.isRemoved = isRemoved;
+        this.deletedAt = deletedAt;
+    }
+
+    // 영속화 후 ID 할당
+    public void assignId(Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/com/network/sse/chat_message/domain/dto/PostSendChatMessage.java
+++ b/src/main/java/com/network/sse/chat_message/domain/dto/PostSendChatMessage.java
@@ -1,0 +1,11 @@
+package com.network.sse.chat_message.domain.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PostSendChatMessage {
+    private long chatRoomId;
+    private long senderId;
+    private long receiverId;
+    private String messageContent;
+}

--- a/src/main/java/com/network/sse/chat_message/infrastructure/ChatMessageEntity.java
+++ b/src/main/java/com/network/sse/chat_message/infrastructure/ChatMessageEntity.java
@@ -1,0 +1,80 @@
+package com.network.sse.chat_message.infrastructure;
+
+import com.network.sse.chat_message.domain.ChatMessage;
+import com.network.sse.chat_room.infrastructure.ChatRoomEntity;
+import com.network.sse.common.infrastructure.BaseEntity;
+import com.network.sse.user.infrastructure.UserEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "ChatMessage")
+public class ChatMessageEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "roomId", nullable = false)
+    private ChatRoomEntity chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "senderId", nullable = false)
+    private UserEntity sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiverId", nullable = false)
+    private UserEntity receiver;
+
+    @Column(name = "content", nullable = false, length = 2000)
+    private String content;
+
+    @Column(name = "isRemoved", nullable = false)
+    private boolean isRemoved;
+
+    @Column(name = "deletedAt")
+    private LocalDateTime deletedAt;
+
+    public static ChatMessageEntity fromModel(ChatMessage chatMessage) {
+        ChatMessageEntity chatMessageEntity = new ChatMessageEntity();
+
+        chatMessageEntity.id = chatMessage.getId();
+        chatMessageEntity.chatRoom = ChatRoomEntity.fromModel(chatMessage.getChatRoom());
+        chatMessageEntity.sender = UserEntity.fromModel(chatMessage.getSender());
+        chatMessageEntity.receiver = UserEntity.fromModel(chatMessage.getReceiver());
+        chatMessageEntity.content = chatMessage.getContent();
+        chatMessageEntity.isRemoved = chatMessage.isRemoved();
+        chatMessageEntity.deletedAt = chatMessage.getDeletedAt();
+
+        return chatMessageEntity;
+    }
+
+    public ChatMessage toModel() {
+        // Entity를 Model로 변환한다
+        ChatMessage chatMessage = ChatMessage.builder()
+                .id(id)
+                .chatRoom(chatRoom.toModel())
+                .sender(sender.toModel())
+                .receiver(receiver.toModel())
+                .content(content)
+                .isRemoved(isRemoved)
+                .deletedAt(deletedAt)
+                .build();
+
+        // Model의 정보를 DB 정보와 동기화한다
+        chatMessage.syncWithPersistence(getCreatedAt(), getUpdatedAt(), getStatus());
+        return chatMessage;
+    }
+}

--- a/src/main/java/com/network/sse/chat_message/infrastructure/ChatMessageJpaRepository.java
+++ b/src/main/java/com/network/sse/chat_message/infrastructure/ChatMessageJpaRepository.java
@@ -1,0 +1,9 @@
+package com.network.sse.chat_message.infrastructure;
+
+import com.network.sse.common.domain.Status;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageJpaRepository extends JpaRepository<ChatMessageEntity, Long> {
+    Optional<ChatMessageEntity> findByIdAndStatus(Long id, Status status);
+}

--- a/src/main/java/com/network/sse/chat_message/infrastructure/ChatMessageRepositoryImpl.java
+++ b/src/main/java/com/network/sse/chat_message/infrastructure/ChatMessageRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.network.sse.chat_message.infrastructure;
+
+import com.network.sse.chat_message.domain.ChatMessage;
+import com.network.sse.chat_message.service.port.ChatMessageRepository;
+import com.network.sse.common.domain.Status;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatMessageRepositoryImpl implements ChatMessageRepository {
+    private final ChatMessageJpaRepository chatMessageJpaRepository;
+
+    @Override
+    public ChatMessage save(ChatMessage chatMessage) {
+        return chatMessageJpaRepository.save(ChatMessageEntity.fromModel(chatMessage)).toModel();
+    }
+
+    @Override
+    public Optional<ChatMessage> findByIdAndStatus(Long id, Status status) {
+        return chatMessageJpaRepository.findByIdAndStatus(id, status).map(ChatMessageEntity::toModel);
+    }
+}

--- a/src/main/java/com/network/sse/chat_message/service/ChatMessageService.java
+++ b/src/main/java/com/network/sse/chat_message/service/ChatMessageService.java
@@ -1,0 +1,45 @@
+package com.network.sse.chat_message.service;
+
+import com.network.sse.chat_message.domain.ChatMessage;
+import com.network.sse.chat_message.domain.dto.PostSendChatMessage;
+import com.network.sse.chat_message.service.port.ChatMessageRepository;
+import com.network.sse.chat_room.domain.ChatRoom;
+import com.network.sse.chat_room.service.ChatRoomService;
+import com.network.sse.common.domain.Status;
+import com.network.sse.common.domain.exception.ResourceNotFoundException;
+import com.network.sse.user.domain.User;
+import com.network.sse.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+    private final ChatRoomService chatRoomService;
+    private final UserService userService;
+
+    private final ChatMessageRepository chatMessageRepository;
+
+    /*메시지 전송*/
+    public ChatMessage saveChatMessage(PostSendChatMessage postSendChatMessage) {
+        // 요청받은 id값을 가진 각 객체 조회
+        ChatRoom chatRoom = chatRoomService.findByIdAndStatus(postSendChatMessage.getChatRoomId(), Status.ACTIVE);
+        User sender = userService.findByIdAndStatus(postSendChatMessage.getSenderId(), Status.ACTIVE);
+        User receiver = userService.findByIdAndStatus(postSendChatMessage.getReceiverId(), Status.ACTIVE);
+
+        // 채팅 메시지 객체 생성 및 저장
+        ChatMessage chatMessage = ChatMessage.builder()
+                .chatRoom(chatRoom)
+                .sender(sender)
+                .receiver(receiver)
+                .content(postSendChatMessage.getMessageContent())
+                .isRemoved(false)
+                .build();
+        return chatMessageRepository.save(chatMessage);
+    }
+
+    /*메시지 조회*/
+    public ChatMessage getChatMessage(long messageId) {
+        return chatMessageRepository.findByIdAndStatus(messageId, Status.ACTIVE).orElseThrow(() -> new ResourceNotFoundException("User", messageId));
+    }
+}

--- a/src/main/java/com/network/sse/chat_message/service/port/ChatMessageRepository.java
+++ b/src/main/java/com/network/sse/chat_message/service/port/ChatMessageRepository.java
@@ -1,0 +1,10 @@
+package com.network.sse.chat_message.service.port;
+
+import com.network.sse.chat_message.domain.ChatMessage;
+import com.network.sse.common.domain.Status;
+import java.util.Optional;
+
+public interface ChatMessageRepository {
+    ChatMessage save(ChatMessage chatMessage);
+    Optional<ChatMessage> findByIdAndStatus(Long id, Status status);
+}

--- a/src/main/java/com/network/sse/chat_room/controller/ChatRoomController.java
+++ b/src/main/java/com/network/sse/chat_room/controller/ChatRoomController.java
@@ -1,0 +1,27 @@
+package com.network.sse.chat_room.controller;
+
+import com.network.sse.chat_room.service.ChatRoomService;
+import com.network.sse.common.domain.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("chat-room")
+@RequiredArgsConstructor
+public class ChatRoomController {
+    private final ChatRoomService chatRoomService;
+
+     /*채팅 방 입장*/
+    @PostMapping("/enter/{chat-room-id}/{user-id}")
+    public BaseResponse<String> enterChatRoom(@PathVariable(name = "chat-room-id") Long chatRoomId,
+                                @PathVariable(name = "user-id") Long userId
+    ) {
+        chatRoomService.enterChatRoom(chatRoomId, userId);
+
+        return new BaseResponse<>("요청에 성공하였습니다.", HttpStatus.OK.value(), userId + "번 유저가 " + chatRoomId + "번 채팅방에 입장했습니다.");
+    }
+}

--- a/src/main/java/com/network/sse/chat_room/domain/ChatRoom.java
+++ b/src/main/java/com/network/sse/chat_room/domain/ChatRoom.java
@@ -1,0 +1,25 @@
+package com.network.sse.chat_room.domain;
+
+import com.network.sse.common.domain.Base;
+import com.network.sse.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ChatRoom extends Base {
+    private Long id;
+    private User owner;
+    private String name;
+
+    @Builder
+    public ChatRoom(Long id, User owner, String name) {
+        this.id = id;
+        this.owner = owner;
+        this.name = name;
+    }
+
+    // 영속화 후 ID 할당
+    public void assignId(Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/com/network/sse/chat_room/domain/ChatRoomMember.java
+++ b/src/main/java/com/network/sse/chat_room/domain/ChatRoomMember.java
@@ -1,0 +1,27 @@
+package com.network.sse.chat_room.domain;
+
+import com.network.sse.common.domain.Base;
+import com.network.sse.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ChatRoomMember extends Base {
+    private Long id;
+    private ChatRoom room;
+    private User member;
+    private boolean isExited = false;
+
+    @Builder
+    public ChatRoomMember(Long id, ChatRoom room, User member, boolean isExited) {
+        this.id = id;
+        this.room = room;
+        this.member = member;
+        this.isExited = isExited;
+    }
+
+    // 영속화 후 ID 할당
+    public void assignId(Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/com/network/sse/chat_room/infrastructure/ChatRoomEntity.java
+++ b/src/main/java/com/network/sse/chat_room/infrastructure/ChatRoomEntity.java
@@ -1,0 +1,56 @@
+package com.network.sse.chat_room.infrastructure;
+
+import com.network.sse.chat_room.domain.ChatRoom;
+import com.network.sse.common.infrastructure.BaseEntity;
+import com.network.sse.user.infrastructure.UserEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "ChatRoom")
+public class ChatRoomEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ownerId", nullable = false)
+    private UserEntity owner;
+
+    @Column(name = "name", nullable = false, length = 200)
+    private String name;
+
+    public static ChatRoomEntity fromModel(ChatRoom chatRoom) {
+        ChatRoomEntity chatRoomEntity = new ChatRoomEntity();
+
+        chatRoomEntity.id = chatRoom.getId();
+        chatRoomEntity.owner = UserEntity.fromModel(chatRoom.getOwner());
+        chatRoomEntity.name = chatRoom.getName();
+
+        return chatRoomEntity;
+    }
+
+    public ChatRoom toModel() {
+        // Entity를 Model로 변환한다
+        ChatRoom chatRoom = ChatRoom.builder()
+                .id(id)
+                .owner(owner.toModel())
+                .name(name)
+                .build();
+
+        // Model의 정보를 DB 정보와 동기화한다
+        chatRoom.syncWithPersistence(getCreatedAt(), getUpdatedAt(), getStatus());
+        return chatRoom;
+    }
+}

--- a/src/main/java/com/network/sse/chat_room/infrastructure/ChatRoomJpaRepository.java
+++ b/src/main/java/com/network/sse/chat_room/infrastructure/ChatRoomJpaRepository.java
@@ -1,0 +1,9 @@
+package com.network.sse.chat_room.infrastructure;
+
+import com.network.sse.common.domain.Status;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomJpaRepository extends JpaRepository<ChatRoomEntity, Long> {
+    Optional<ChatRoomEntity> findByIdAndStatus(Long id, Status status);
+}

--- a/src/main/java/com/network/sse/chat_room/infrastructure/ChatRoomMemberEntity.java
+++ b/src/main/java/com/network/sse/chat_room/infrastructure/ChatRoomMemberEntity.java
@@ -1,0 +1,62 @@
+package com.network.sse.chat_room.infrastructure;
+
+import com.network.sse.chat_room.domain.ChatRoomMember;
+import com.network.sse.common.infrastructure.BaseEntity;
+import com.network.sse.user.infrastructure.UserEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "ChatRoomMember")
+public class ChatRoomMemberEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "roomId", nullable = false)
+    private ChatRoomEntity room;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberId", nullable = false)
+    private UserEntity member;
+
+    @Column(name = "isExited", nullable = false)
+    private boolean isExited = false;
+
+    public static ChatRoomMemberEntity fromModel(ChatRoomMember chatRoomMember) {
+        ChatRoomMemberEntity chatRoomMemberEntity = new ChatRoomMemberEntity();
+
+        chatRoomMemberEntity.id = chatRoomMember.getId();
+        chatRoomMemberEntity.room = ChatRoomEntity.fromModel(chatRoomMember.getRoom());
+        chatRoomMemberEntity.member = UserEntity.fromModel(chatRoomMember.getMember());
+        chatRoomMemberEntity.isExited = chatRoomMember.isExited();
+
+        return chatRoomMemberEntity;
+    }
+
+    public ChatRoomMember toModel() {
+        // Entity를 Model로 변환한다
+        ChatRoomMember chatRoomMember = ChatRoomMember.builder()
+                .id(id)
+                .room(room.toModel())
+                .member(member.toModel())
+                .isExited(isExited)
+                .build();
+
+        // Model의 정보를 DB 정보와 동기화한다
+        chatRoomMember.syncWithPersistence(getCreatedAt(), getUpdatedAt(), getStatus());
+        return chatRoomMember;
+    }
+}

--- a/src/main/java/com/network/sse/chat_room/infrastructure/ChatRoomMemberJpaRepository.java
+++ b/src/main/java/com/network/sse/chat_room/infrastructure/ChatRoomMemberJpaRepository.java
@@ -1,0 +1,6 @@
+package com.network.sse.chat_room.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomMemberJpaRepository extends JpaRepository<ChatRoomMemberEntity, Long> {
+}

--- a/src/main/java/com/network/sse/chat_room/infrastructure/ChatRoomMemberRepositoryImpl.java
+++ b/src/main/java/com/network/sse/chat_room/infrastructure/ChatRoomMemberRepositoryImpl.java
@@ -1,0 +1,17 @@
+package com.network.sse.chat_room.infrastructure;
+
+import com.network.sse.chat_room.domain.ChatRoomMember;
+import com.network.sse.chat_room.service.port.ChatRoomMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatRoomMemberRepositoryImpl implements ChatRoomMemberRepository {
+    private final ChatRoomMemberJpaRepository chatRoomMemberJpaRepository;
+
+    @Override
+    public ChatRoomMember save(ChatRoomMember chatRoomMember) {
+        return chatRoomMemberJpaRepository.save(ChatRoomMemberEntity.fromModel(chatRoomMember)).toModel();
+    }
+}

--- a/src/main/java/com/network/sse/chat_room/infrastructure/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/network/sse/chat_room/infrastructure/ChatRoomRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.network.sse.chat_room.infrastructure;
+
+import com.network.sse.chat_room.domain.ChatRoom;
+import com.network.sse.chat_room.service.port.ChatRoomRepository;
+import com.network.sse.common.domain.Status;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatRoomRepositoryImpl implements ChatRoomRepository {
+    private final ChatRoomJpaRepository chatRoomJpaRepository;
+
+    @Override
+    public Optional<ChatRoom> findByIdAndStatus(Long id, Status status) {
+        return chatRoomJpaRepository.findByIdAndStatus(id, status).map(ChatRoomEntity::toModel);
+    }
+
+    @Override
+    public ChatRoom save(ChatRoom chatRoom) {
+        return chatRoomJpaRepository.save(ChatRoomEntity.fromModel(chatRoom)).toModel();
+    }
+}

--- a/src/main/java/com/network/sse/chat_room/service/ChatRoomService.java
+++ b/src/main/java/com/network/sse/chat_room/service/ChatRoomService.java
@@ -1,0 +1,40 @@
+package com.network.sse.chat_room.service;
+
+import com.network.sse.chat_room.domain.ChatRoom;
+import com.network.sse.chat_room.domain.ChatRoomMember;
+import com.network.sse.chat_room.service.port.ChatRoomMemberRepository;
+import com.network.sse.chat_room.service.port.ChatRoomRepository;
+import com.network.sse.common.domain.Status;
+import com.network.sse.common.domain.exception.ResourceNotFoundException;
+import com.network.sse.user.domain.User;
+import com.network.sse.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+    private final UserService userService;
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+    public ChatRoom findByIdAndStatus(Long id, Status status) {
+        return chatRoomRepository.findByIdAndStatus(id, status).orElseThrow(() -> new ResourceNotFoundException("ChatRoom", id));
+    }
+
+    /*채팅 방 입장*/
+    public void enterChatRoom(Long chatRoomId, Long userId) {
+        // 요청받은 id값을 가진 각 객체 조회
+        ChatRoom chatRoom = findByIdAndStatus(chatRoomId, Status.ACTIVE);
+        User user = userService.findByIdAndStatus(userId, Status.ACTIVE);
+
+        // '채팅방 멤버' 객체 생성 및 저장
+        ChatRoomMember chatRoomMember = ChatRoomMember.builder()
+                .room(chatRoom)
+                .member(user)
+                .isExited(false)
+                .build();
+        chatRoomMemberRepository.save(chatRoomMember);
+    }
+}

--- a/src/main/java/com/network/sse/chat_room/service/port/ChatRoomMemberRepository.java
+++ b/src/main/java/com/network/sse/chat_room/service/port/ChatRoomMemberRepository.java
@@ -1,0 +1,7 @@
+package com.network.sse.chat_room.service.port;
+
+import com.network.sse.chat_room.domain.ChatRoomMember;
+
+public interface ChatRoomMemberRepository {
+    ChatRoomMember save(ChatRoomMember chatRoomMember);
+}

--- a/src/main/java/com/network/sse/chat_room/service/port/ChatRoomRepository.java
+++ b/src/main/java/com/network/sse/chat_room/service/port/ChatRoomRepository.java
@@ -1,0 +1,10 @@
+package com.network.sse.chat_room.service.port;
+
+import com.network.sse.chat_room.domain.ChatRoom;
+import com.network.sse.common.domain.Status;
+import java.util.Optional;
+
+public interface ChatRoomRepository {
+    Optional<ChatRoom> findByIdAndStatus(Long id, Status status);
+    ChatRoom save(ChatRoom chatRoom);
+}

--- a/src/main/java/com/network/sse/common/domain/Base.java
+++ b/src/main/java/com/network/sse/common/domain/Base.java
@@ -1,0 +1,18 @@
+package com.network.sse.common.domain;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class Base {
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    protected Status status;
+
+    // DB 정보와 동기화
+    public void syncWithPersistence(LocalDateTime createdAt, LocalDateTime updatedAt, Status status) {
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/network/sse/common/domain/BaseResponse.java
+++ b/src/main/java/com/network/sse/common/domain/BaseResponse.java
@@ -1,0 +1,12 @@
+package com.network.sse.common.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BaseResponse<T> {
+    private final String message;
+    private final int code;
+    private T result;
+}

--- a/src/main/java/com/network/sse/common/domain/Status.java
+++ b/src/main/java/com/network/sse/common/domain/Status.java
@@ -1,0 +1,5 @@
+package com.network.sse.common.domain;
+
+public enum Status {
+    ACTIVE, INACTIVE
+}

--- a/src/main/java/com/network/sse/common/domain/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/network/sse/common/domain/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.network.sse.common.domain.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String datasource, Long id) {
+        super(datasource + "에서 ID " + id + "를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/network/sse/common/infrastructure/BaseEntity.java
+++ b/src/main/java/com/network/sse/common/infrastructure/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.network.sse.common.infrastructure;
+
+import com.network.sse.common.domain.Status;
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Getter
+@MappedSuperclass
+public class BaseEntity {
+    @CreationTimestamp
+    @Column(name = "createdAt", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+    @UpdateTimestamp
+    @Column(name = "updatedAt", nullable = false)
+    private LocalDateTime updatedAt;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, columnDefinition = "VARCHAR(16)", length = 16)
+    protected Status status = Status.ACTIVE;
+}

--- a/src/main/java/com/network/sse/common/infrastructure/BaseEntity.java
+++ b/src/main/java/com/network/sse/common/infrastructure/BaseEntity.java
@@ -2,18 +2,21 @@ package com.network.sse.common.infrastructure;
 
 import com.network.sse.common.domain.Status;
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
-import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
-    @CreationTimestamp
+    @CreatedDate
     @Column(name = "createdAt", nullable = false, updatable = false)
     private LocalDateTime createdAt;
     @UpdateTimestamp

--- a/src/main/java/com/network/sse/user/domain/User.java
+++ b/src/main/java/com/network/sse/user/domain/User.java
@@ -1,0 +1,28 @@
+package com.network.sse.user.domain;
+
+import com.network.sse.common.domain.Base;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class User extends Base {
+    private Long id;
+    private String email;
+    private String password;
+    private String nickname;
+    private String profileImage;
+
+    @Builder
+    public User(Long id, String email, String password, String nickname, String profileImage) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+    }
+
+    // 영속화 후 ID 할당
+    public void assignId(Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/com/network/sse/user/infrastructure/UserEntity.java
+++ b/src/main/java/com/network/sse/user/infrastructure/UserEntity.java
@@ -1,0 +1,61 @@
+package com.network.sse.user.infrastructure;
+
+import com.network.sse.common.infrastructure.BaseEntity;
+import com.network.sse.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "User")
+public class UserEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "email", nullable = false, length = 30)
+    private String email;
+
+    @Column(name = "password", nullable = false, length = 100)
+    private String password;
+
+    @Column(name = "nickname", nullable = false, length = 50)
+    private String nickname;
+
+    @Column(name = "profile_image", length = 2000)
+    private String profileImage;
+
+    public static UserEntity fromModel(User user) {
+        UserEntity userEntity = new UserEntity();
+
+        userEntity.id = user.getId();
+        userEntity.email = user.getEmail();
+        userEntity.password = user.getPassword();
+        userEntity.nickname = user.getNickname();
+        userEntity.profileImage = user.getProfileImage();
+
+        return userEntity;
+    }
+
+    public User toModel() {
+        // Entity를 Model로 변환한다
+        User user = User.builder()
+                .id(id)
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .profileImage(profileImage)
+                .build();
+
+        // Model의 정보를 DB 정보와 동기화한다
+        user.syncWithPersistence(getCreatedAt(), getUpdatedAt(), getStatus());
+        return user;
+    }
+}

--- a/src/main/java/com/network/sse/user/infrastructure/UserJpaRepository.java
+++ b/src/main/java/com/network/sse/user/infrastructure/UserJpaRepository.java
@@ -1,0 +1,9 @@
+package com.network.sse.user.infrastructure;
+
+import com.network.sse.common.domain.Status;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
+    Optional<UserEntity> findByIdAndStatus(Long id, Status status);
+}

--- a/src/main/java/com/network/sse/user/infrastructure/UserRepositoryImpl.java
+++ b/src/main/java/com/network/sse/user/infrastructure/UserRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.network.sse.user.infrastructure;
+
+import com.network.sse.common.domain.Status;
+import com.network.sse.user.domain.User;
+import com.network.sse.user.service.port.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public Optional<User> findByIdAndStatus(Long id, Status status) {
+        return userJpaRepository.findByIdAndStatus(id, status).map(UserEntity::toModel);
+    }
+}

--- a/src/main/java/com/network/sse/user/service/UserService.java
+++ b/src/main/java/com/network/sse/user/service/UserService.java
@@ -1,0 +1,18 @@
+package com.network.sse.user.service;
+
+import com.network.sse.common.domain.Status;
+import com.network.sse.common.domain.exception.ResourceNotFoundException;
+import com.network.sse.user.domain.User;
+import com.network.sse.user.service.port.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public User findByIdAndStatus(Long id, Status status) {
+        return userRepository.findByIdAndStatus(id, status).orElseThrow(() -> new ResourceNotFoundException("User", id));
+    }
+}

--- a/src/main/java/com/network/sse/user/service/port/UserRepository.java
+++ b/src/main/java/com/network/sse/user/service/port/UserRepository.java
@@ -1,0 +1,9 @@
+package com.network.sse.user.service.port;
+
+import com.network.sse.common.domain.Status;
+import com.network.sse.user.domain.User;
+import java.util.Optional;
+
+public interface UserRepository {
+    Optional<User> findByIdAndStatus(Long id, Status status);
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #1 

## 📝 작업 내용

**1. 패키지 구조 및 도메인, 엔티티 생성**
- 도메인이 드러나도록 패키지 구조를 잡았어요 
- MVC 패턴에 도메인 계층을 추가해 영속성 객체와 구분되는 도메인 엔티티를 생성했어요

**2. 응답값을 구조화 한 BaseResponse를 생성했어요**

**3. 메시지 주고받기 기능의 가장 기본이 되는 API를 구현했어요**
- 메시지 전송 API: 메시지를 전송하는 API에요
- 특정 메시지 조회 API: DB의 id값에 해당하는 특정 메시지를 조회하는 API에요

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
채팅에 관해 도메인 나누는 범위를 고민했어요

 <**방법 A**. 채팅을 하나의 도메인으로 잡고, 채팅 내용과 채팅방은 관리 차원에서 채팅의 하위 도메인으로 나누어요>
📦sse
 ┣ 📂chat
 ┃ ┣ 📂content
 ┃ ┃ ┣ 📂controller
 ┃ ┃ ┣ 📂domain
 ┃ ┃ ┣ 📂infrastructure
 ┃ ┃ ┗ 📂service
 ┃ ┗ 📂room
 ┃ ┃ ┣ 📂controller
 ┃ ┃ ┣ 📂domain
 ┃ ┃ ┣ 📂infrastructure
 ┃ ┃ ┗ 📂service
 ┗ 

특징
- room과 content가 각각의 하위 도메인으로 나누어져 모듈화가 잘 되어 있어요
- room과 content 각각의 기능이 많아질 경우, 확장이 쉬워요
- room과 content를 응집력있게 관리할 수 있어요

 <**방법 B**. 채팅만 도메인으로 잡고, 채팅 내용과 채팅방은 controller, service, infrastructure, domain 안에서 파일로 구분해요>
📦sse
 ┣ 📂chat
 ┃ ┣ 📂controller
 ┃ ┃ ┣ 📜RoomController.java
 ┃ ┃ ┗ 📜ContentController.java
 ┃ ┣ 📂domain
 ┃ ┣ 📂infrastructure
 ┃ ┗ 📂service
 ┗

특징
- 파일이 적고 구조가 단순해서 관리가 쉬워요
- room과 content가 개별적인 도메인으로 기능이 확장될 경우 chat 하위 패키지가 과도하게 복잡해질 수 있어요

<**방법 C**. 처음부터 채팅 내용과 채팅방을 각각 도메인으로 구성해 관리해요>
📦sse
 ┣ 📂chat_content
 ┃ ┣ 📂controller
 ┃ ┣ 📂domain
 ┃ ┣ 📂infrastructure
 ┃ ┗ 📂service
 ┣ 📂chat_room
 ┃ ┣ 📂controller
 ┃ ┣ 📂domain
 ┃ ┣ 📂infrastructure
 ┃ ┗ 📂service
 ┗

특징
- 첫 번째 레이어에서 세부적으로 구분하가 때문에 도메인 경계를 명확히 구분할 수 있어서 직관적이에요
- 방법A와 일부 구성이 동일한데, chat이라는 상위 도메인이 없어짐으로써 불필요한 계층이 줄어들어요

<**결론**>
저는 도메인 경계를 명확히 구분해서 관리하고자 해요. 또한 기능의 확장 가능성을 고려하여 방법 C를 선택했어요!