### PR TITLE
빌더패턴의 생성자 및 필드 기본값 부여 방식 수정

### DIFF
--- a/src/main/java/com/network/sse/chat_message/domain/ChatMessage.java
+++ b/src/main/java/com/network/sse/chat_message/domain/ChatMessage.java
@@ -2,6 +2,7 @@ package com.network.sse.chat_message.domain;
 
 import com.network.sse.chat_room.domain.ChatRoom;
 import com.network.sse.common.domain.Base;
+import com.network.sse.common.domain.Status;
 import com.network.sse.user.domain.User;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -14,12 +15,14 @@ public class ChatMessage extends Base {
     private User sender;
     private User receiver;
     private String content;
-    private boolean isRemoved;
+    private boolean isRemoved = false;
     private LocalDateTime deletedAt;
 
     @Builder
-    public ChatMessage(Long id, ChatRoom chatRoom, User sender, User receiver, String content, boolean isRemoved, LocalDateTime deletedAt) {
-        this.id = id;
+    public ChatMessage(ChatRoom chatRoom, User sender, User receiver, String content, boolean isRemoved, LocalDateTime deletedAt) {
+        if (chatRoom == null || sender == null || receiver == null || content == null) {
+            throw new IllegalArgumentException("필수 필드는 null일 수 없습니다.");
+        }
         this.chatRoom = chatRoom;
         this.sender = sender;
         this.receiver = receiver;
@@ -31,5 +34,11 @@ public class ChatMessage extends Base {
     // 영속화 후 ID 할당
     public void assignId(Long id) {
         this.id = id;
+    }
+
+    public void remove() {
+        this.isRemoved = true;
+        this.deletedAt = LocalDateTime.now();
+        this.status = Status.INACTIVE;
     }
 }

--- a/src/main/java/com/network/sse/chat_room/domain/ChatRoom.java
+++ b/src/main/java/com/network/sse/chat_room/domain/ChatRoom.java
@@ -12,8 +12,11 @@ public class ChatRoom extends Base {
     private String name;
 
     @Builder
-    public ChatRoom(Long id, User owner, String name) {
-        this.id = id;
+    public ChatRoom(User owner, String name) {
+        if (owner == null || name == null) {
+            throw new IllegalArgumentException("필수 필드는 null일 수 없습니다.");
+        }
+
         this.owner = owner;
         this.name = name;
     }

--- a/src/main/java/com/network/sse/chat_room/domain/ChatRoomMember.java
+++ b/src/main/java/com/network/sse/chat_room/domain/ChatRoomMember.java
@@ -13,8 +13,10 @@ public class ChatRoomMember extends Base {
     private boolean isExited = false;
 
     @Builder
-    public ChatRoomMember(Long id, ChatRoom room, User member, boolean isExited) {
-        this.id = id;
+    public ChatRoomMember(ChatRoom room, User member, boolean isExited) {
+        if (room == null || member == null) {
+            throw new IllegalArgumentException("필수 필드는 null일 수 없습니다.");
+        }
         this.room = room;
         this.member = member;
         this.isExited = isExited;

--- a/src/main/java/com/network/sse/chat_room/infrastructure/ChatRoomEntity.java
+++ b/src/main/java/com/network/sse/chat_room/infrastructure/ChatRoomEntity.java
@@ -34,7 +34,9 @@ public class ChatRoomEntity extends BaseEntity {
     public static ChatRoomEntity fromModel(ChatRoom chatRoom) {
         ChatRoomEntity chatRoomEntity = new ChatRoomEntity();
 
-        chatRoomEntity.id = chatRoom.getId();
+        if (chatRoom.getId() != null) {
+            chatRoomEntity.id = chatRoom.getId(); // 이미 id가 부여된 엔티티를 모델로 쓰다가 다시 엔티티로 변경하는 경우, id가 초기화 되는 것 방지
+        }
         chatRoomEntity.owner = UserEntity.fromModel(chatRoom.getOwner());
         chatRoomEntity.name = chatRoom.getName();
 
@@ -44,10 +46,12 @@ public class ChatRoomEntity extends BaseEntity {
     public ChatRoom toModel() {
         // Entity를 Model로 변환한다
         ChatRoom chatRoom = ChatRoom.builder()
-                .id(id)
                 .owner(owner.toModel())
                 .name(name)
                 .build();
+
+        // id 할당
+        chatRoom.assignId(id);
 
         // Model의 정보를 DB 정보와 동기화한다
         chatRoom.syncWithPersistence(getCreatedAt(), getUpdatedAt(), getStatus());

--- a/src/main/java/com/network/sse/chat_room/infrastructure/ChatRoomMemberEntity.java
+++ b/src/main/java/com/network/sse/chat_room/infrastructure/ChatRoomMemberEntity.java
@@ -32,13 +32,15 @@ public class ChatRoomMemberEntity extends BaseEntity {
     @JoinColumn(name = "memberId", nullable = false)
     private UserEntity member;
 
-    @Column(name = "isExited", nullable = false)
+    @Column(name = "isExited", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private boolean isExited = false;
 
     public static ChatRoomMemberEntity fromModel(ChatRoomMember chatRoomMember) {
         ChatRoomMemberEntity chatRoomMemberEntity = new ChatRoomMemberEntity();
 
-        chatRoomMemberEntity.id = chatRoomMember.getId();
+        if (chatRoomMember.getId() != null) {
+            chatRoomMemberEntity.id = chatRoomMember.getId(); // 이미 id가 부여된 엔티티를 모델로 쓰다가 다시 엔티티로 변경하는 경우, id가 초기화 되는 것 방지
+        }
         chatRoomMemberEntity.room = ChatRoomEntity.fromModel(chatRoomMember.getRoom());
         chatRoomMemberEntity.member = UserEntity.fromModel(chatRoomMember.getMember());
         chatRoomMemberEntity.isExited = chatRoomMember.isExited();
@@ -49,11 +51,13 @@ public class ChatRoomMemberEntity extends BaseEntity {
     public ChatRoomMember toModel() {
         // Entity를 Model로 변환한다
         ChatRoomMember chatRoomMember = ChatRoomMember.builder()
-                .id(id)
                 .room(room.toModel())
                 .member(member.toModel())
                 .isExited(isExited)
                 .build();
+
+        // id 할당
+        chatRoomMember.assignId(id);
 
         // Model의 정보를 DB 정보와 동기화한다
         chatRoomMember.syncWithPersistence(getCreatedAt(), getUpdatedAt(), getStatus());

--- a/src/main/java/com/network/sse/common/infrastructure/BaseEntity.java
+++ b/src/main/java/com/network/sse/common/infrastructure/BaseEntity.java
@@ -23,6 +23,6 @@ public class BaseEntity {
     @Column(name = "updatedAt", nullable = false)
     private LocalDateTime updatedAt;
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, columnDefinition = "VARCHAR(16)", length = 16)
+    @Column(name = "status", nullable = false, columnDefinition = "VARCHAR(16) DEFAULT 'ACTIVE'", length = 16)
     protected Status status = Status.ACTIVE;
 }

--- a/src/main/java/com/network/sse/user/domain/User.java
+++ b/src/main/java/com/network/sse/user/domain/User.java
@@ -13,8 +13,10 @@ public class User extends Base {
     private String profileImage;
 
     @Builder
-    public User(Long id, String email, String password, String nickname, String profileImage) {
-        this.id = id;
+    public User(String email, String password, String nickname, String profileImage) {
+        if (email == null || password == null || nickname == null) {
+            throw new IllegalArgumentException("필수 필드는 null일 수 없습니다.");
+        }
         this.email = email;
         this.password = password;
         this.nickname = nickname;

--- a/src/main/java/com/network/sse/user/infrastructure/UserEntity.java
+++ b/src/main/java/com/network/sse/user/infrastructure/UserEntity.java
@@ -35,7 +35,9 @@ public class UserEntity extends BaseEntity {
     public static UserEntity fromModel(User user) {
         UserEntity userEntity = new UserEntity();
 
-        userEntity.id = user.getId();
+        if (user.getId() != null) {
+            userEntity.id = user.getId(); // 이미 id가 부여된 엔티티를 모델로 쓰다가 다시 엔티티로 변경하는 경우, id가 초기화 되는 것 방지
+        }
         userEntity.email = user.getEmail();
         userEntity.password = user.getPassword();
         userEntity.nickname = user.getNickname();
@@ -47,12 +49,14 @@ public class UserEntity extends BaseEntity {
     public User toModel() {
         // Entity를 Model로 변환한다
         User user = User.builder()
-                .id(id)
                 .email(email)
                 .password(password)
                 .nickname(nickname)
                 .profileImage(profileImage)
                 .build();
+
+        // id 할당
+        user.assignId(id);
 
         // Model의 정보를 DB 정보와 동기화한다
         user.syncWithPersistence(getCreatedAt(), getUpdatedAt(), getStatus());


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #3 

## 📝 작업 내용

- 클래스가 아닌, 생성자에 Builder를 사용하는 방식을 선택한 이유를 코드에 반영했어요
    - 필수 필드와 선택적 필드를 구분했어요
    : 객체의 무결성을 위해 생성자에서 필수 필드를 강제하도록 유효성 검사 로직을 추가했어요
    - id는 영속화 이후에 값이 할당되는 필드인데, 빌더에 포함되어 있어 객체 생성 시 혼란을 초래할 가능성이 있으므로 제거했어요
    
- not null이어야 하는 필드의 기본값 부여 방식을 수정했어요
: 객체를 생성할 때 뿐만 아니라 DDL로 DB에도 기본값이 설정되도록 했어요

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
