### PR TITLE
SSE를 활용한 실시간 채팅 구현

### DIFF
--- a/src/main/java/com/network/sse/chat_message/controller/ChatMessageController.java
+++ b/src/main/java/com/network/sse/chat_message/controller/ChatMessageController.java
@@ -4,6 +4,7 @@ import com.network.sse.chat_message.domain.ChatMessage;
 import com.network.sse.chat_message.domain.dto.PostSendChatMessage;
 import com.network.sse.chat_message.service.ChatMessageService;
 import com.network.sse.common.domain.BaseResponse;
+import com.network.sse.transport.service.TransportService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ChatMessageController {
     private final ChatMessageService chatMessageService;
+    private final TransportService transportService;
 
     /*메시지 전송*/
     @PostMapping("")
@@ -26,6 +28,9 @@ public class ChatMessageController {
             ) {
         // 채팅 메시지 객체 생성 및 저장
         ChatMessage chatMessage = chatMessageService.saveChatMessage(postSendChatMessage);
+
+        // 해당 채팅방에 있는 멤버들에게 메시지 전송
+        transportService.sendMessage(postSendChatMessage.getChatRoomId(), postSendChatMessage.getReceiverId(), chatMessage);
 
         return new BaseResponse<>("요청에 성공하였습니다.", HttpStatus.OK.value(), chatMessage.getId()+"번의 메시지가 전송되었습니다.");
     }

--- a/src/main/java/com/network/sse/transport/controller/TransportController.java
+++ b/src/main/java/com/network/sse/transport/controller/TransportController.java
@@ -1,0 +1,31 @@
+package com.network.sse.transport.controller;
+
+import com.network.sse.transport.service.TransportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("events")
+@RequiredArgsConstructor
+public class TransportController {
+    private final TransportService transportService;
+
+    /**
+     * 채팅방에 입장한 유저 sse 연결
+     * @param chatRoomId sse에 연결할 채팅방 id
+     * @param userId sse에 연결할 유저 id
+     * @param lastEventId 클라이언트가 마지막으로 수신한 eventId
+     * @return SseEmitter 객체
+     */
+    @GetMapping(value = "/{chat-room-id}/{user-id}", produces = "text/event-stream")
+    public SseEmitter connectSseForChat (@PathVariable(name = "chat-room-id") Long chatRoomId,
+                                @PathVariable(name = "user-id") Long userId,
+                                @RequestHeader(value = "Last-Event-ID", defaultValue = "") String lastEventId) {
+        return transportService.connectSseForChat(chatRoomId, userId, lastEventId);
+    }
+}

--- a/src/main/java/com/network/sse/transport/infrastructure/EmitterRepository.java
+++ b/src/main/java/com/network/sse/transport/infrastructure/EmitterRepository.java
@@ -1,0 +1,10 @@
+package com.network.sse.transport.infrastructure;
+
+import java.util.Map;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface EmitterRepository {
+    SseEmitter save(String emitterId, SseEmitter sseEmitter);
+    Map<String, SseEmitter> findAllEmitterStartWithId(String id);
+    void deleteById(String emitterId);
+}

--- a/src/main/java/com/network/sse/transport/infrastructure/EmitterRepositoryImpl.java
+++ b/src/main/java/com/network/sse/transport/infrastructure/EmitterRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.network.sse.transport.infrastructure;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+public class EmitterRepositoryImpl implements EmitterRepository {
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    @Override
+    public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
+        emitters.put(emitterId, sseEmitter);
+        return sseEmitter;
+    }
+
+    @Override
+    public Map<String, SseEmitter> findAllEmitterStartWithId(String id) {
+        return emitters.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(id))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public void deleteById(String emitterId) {
+        emitters.remove(emitterId);
+    }
+}

--- a/src/main/java/com/network/sse/transport/service/TransportService.java
+++ b/src/main/java/com/network/sse/transport/service/TransportService.java
@@ -1,0 +1,88 @@
+package com.network.sse.transport.service;
+
+import com.network.sse.chat_message.domain.ChatMessage;
+import com.network.sse.transport.infrastructure.EmitterRepository;
+import java.io.IOException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@RequiredArgsConstructor
+public class TransportService {
+    private static final Long SSE_TIMEOUT = 1000 * 10L;
+    private final EmitterRepository emitterRepository;
+
+    /**
+     * emitter id 접두사 생성
+     * @param chatRoomId sse에 연결할 채팅방 id
+     * @param userId sse에 연결할 유저 id
+     * @return emitterId 접두사
+     */
+    private String createEmitterIdPrefix(Long chatRoomId, Long userId) {
+        return chatRoomId + "_" + userId;
+    }
+
+    /**
+     * 유저가 채팅 방 입장시 sse 연결
+     * @param chatRoomId sse에 연결할 채팅방 id
+     * @param userId sse에 연결할 유저 id
+     * @param lastEventId lastEventId 클라이언트가 마지막으로 수신한 eventId
+     * @return SseEmitter 객체
+     */
+    public SseEmitter connectSseForChat(Long chatRoomId, Long userId, String lastEventId) {
+        String emitterIdPrefix = createEmitterIdPrefix(chatRoomId, userId);
+        String emitterId =  emitterIdPrefix + "_" + System.currentTimeMillis();
+        SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(SSE_TIMEOUT));
+
+        emitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
+        emitter.onTimeout(() -> emitterRepository.deleteById(emitterId));
+
+        if (lastEventId == null || lastEventId.isEmpty()) {
+            // 503 error 방지 차원에서 더미 이벤트 전송
+            sendToClient(emitter, emitterId, "EventStream Created... [chatRoomId=%d userId=%d]".formatted(chatRoomId, userId));
+        }
+
+        return emitter;
+    }
+
+    /**
+     * 데이터 전송
+     * @param emitter 사용할 SseEmitter 객체
+     * @param id SseEmitter id
+     * @param data 전송할 데이터 (채팅 메시지...)
+     */
+    private void sendToClient(SseEmitter emitter, String id, Object data) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(id)
+                    .name("chat")
+                    .data(data));
+        } catch (IOException exception) {
+            emitterRepository.deleteById(id);
+            throw new RuntimeException("SSE 연결에 오류가 발생했습니다!");
+        }
+    }
+
+    /**
+     * sse로 실시간 채팅 메시지 전송
+     * @param chatRoomId 채팅방 id
+     * @param receiverId 수신자 user id
+     * @param chatMessage 메시지
+     */
+    public void sendMessage(Long chatRoomId, Long receiverId, ChatMessage chatMessage) {
+        // 데이터를 받아야 하는 유저의 id (receiverId)에 해당하는 emitter
+        String emitterIdPrefix = createEmitterIdPrefix(chatRoomId, receiverId);
+        Map<String, SseEmitter> sseEmitters = emitterRepository.findAllEmitterStartWithId(emitterIdPrefix);
+
+        String eventId = emitterIdPrefix + "_" + System.currentTimeMillis();
+
+        sseEmitters.forEach(
+                (key, emitter) -> {
+                    // 데이터 전송
+                    sendToClient(emitter, eventId, chatMessage.getContent());
+                }
+        );
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #5 

## 📝 작업 내용

SSE를 활용해 실시간 채팅 기능을 만들었어요
- SSE는 별도의 패키지로 분리했어요 (transport 패키지)
: 실시간 통신 관련 로직을 분리해 코드를 명확히 하고, 책임을 분리하기 위함이에요

- SSE에 관한 작업은 크게 두 가지에요
1. SSE 연결
: SseEmitter를 id로 찾아야해서 id값을 `채팅 룸 id_사용자 id`로 의미있게 하되, 유니크한 값을 위해 뒤에 시스템 시간을 추가했어요.

2. SSE를 활용한 실시간 메시지(데이터) 전송
: ChatMessageController에서 메시지를 전송하는 API가 호출될 때, 연관된 SseEmitter에 실시간으로 메시지가 전송돼요

### 스크린샷 (선택)
테스트 결과를 이미지로 첨부할게요. (1번 채팅룸에 있는 2번 유저를 대상으로 테스트했어요)

1. SSE 연결을 맺는 요청을 보내요
<img width="700" alt="스크린샷 2024-12-14 오후 4 16 33" src="https://github.com/user-attachments/assets/2da49e48-8e7e-46e2-a2a1-7674470aba1f" />


2. 메시지를 전송해요
<img width="700" alt="스크린샷 2024-12-14 오후 4 14 37" src="https://github.com/user-attachments/assets/92ad755c-e4c4-4de0-8c0b-dd24dc89a61c" />


3. sse에 연결된 해당 유저는 자신에게 보낸 메시지를 실시간으로 받아요 
<img width="700" alt="스크린샷 2024-12-14 오후 4 13 12" src="https://github.com/user-attachments/assets/a0af2467-347a-4f91-b813-e68218007931" />


## 💬 리뷰 요구사항(선택)
