### PR TITLE
[고도화] SSE 데이터 유실 방지 및 재전송 로직 구현

### DIFF
--- a/src/main/java/com/network/sse/transport/controller/TransportController.java
+++ b/src/main/java/com/network/sse/transport/controller/TransportController.java
@@ -1,7 +1,10 @@
 package com.network.sse.transport.controller;
 
+import com.network.sse.common.domain.BaseResponse;
 import com.network.sse.transport.service.TransportService;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -27,5 +30,21 @@ public class TransportController {
                                 @PathVariable(name = "user-id") Long userId,
                                 @RequestHeader(value = "Last-Event-ID", defaultValue = "") String lastEventId) {
         return transportService.connectSseForChat(chatRoomId, userId, lastEventId);
+    }
+
+    /*모든 SseEmitter 조회*/
+    @GetMapping("/emitters")
+    public BaseResponse<Map<String, String>> getEmitters() {
+        Map<String, String> result =  transportService.getAllEmitters();
+
+        return new BaseResponse<>("요청에 성공하였습니다.", HttpStatus.OK.value(), result);
+    }
+
+    /*모든 event cache 조회*/
+    @GetMapping("/event-cache")
+    public BaseResponse<Map<String, Object>> getEventCache() {
+        Map<String, Object> result =  transportService.getAllEventCache();
+
+        return new BaseResponse<>("요청에 성공하였습니다.", HttpStatus.OK.value(), result);
     }
 }

--- a/src/main/java/com/network/sse/transport/infrastructure/EmitterRepository.java
+++ b/src/main/java/com/network/sse/transport/infrastructure/EmitterRepository.java
@@ -7,4 +7,9 @@ public interface EmitterRepository {
     SseEmitter save(String emitterId, SseEmitter sseEmitter);
     Map<String, SseEmitter> findAllEmitterStartWithId(String id);
     void deleteById(String emitterId);
+    void saveEventCache(String eventCacheId, Object event);
+    Map<String, Object> findAllEventCacheStartWithId(String id);
+    void deleteEventCacheById(String eventCacheId);
+    Map<String, SseEmitter> getAllEmitters();
+    Map<String, Object> getAllEventCache();
 }

--- a/src/main/java/com/network/sse/transport/infrastructure/EmitterRepositoryImpl.java
+++ b/src/main/java/com/network/sse/transport/infrastructure/EmitterRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Repository
 public class EmitterRepositoryImpl implements EmitterRepository {
     private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
 
     @Override
     public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
@@ -26,5 +27,32 @@ public class EmitterRepositoryImpl implements EmitterRepository {
     @Override
     public void deleteById(String emitterId) {
         emitters.remove(emitterId);
+    }
+
+    @Override
+    public void saveEventCache(String eventCacheId, Object event) {
+        eventCache.put(eventCacheId, event);
+    }
+
+    @Override
+    public Map<String, Object> findAllEventCacheStartWithId(String id) {
+        return eventCache.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(id))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public void deleteEventCacheById(String eventCacheId) {
+        eventCache.remove(eventCacheId);
+    }
+
+    @Override
+    public Map<String, SseEmitter> getAllEmitters() {
+        return emitters;
+    }
+
+    @Override
+    public Map<String, Object> getAllEventCache() {
+        return eventCache;
     }
 }

--- a/src/main/java/com/network/sse/transport/service/TransportService.java
+++ b/src/main/java/com/network/sse/transport/service/TransportService.java
@@ -80,6 +80,7 @@ public class TransportService {
         Map<String, Object> events = emitterRepository.findAllEventCacheStartWithId(emitterIdPrefix);
 
         events.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
                 .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
                 .forEach(entry -> {
                     ChatMessage chatMessage = (ChatMessage) entry.getValue();

--- a/src/main/java/com/network/sse/transport/service/TransportService.java
+++ b/src/main/java/com/network/sse/transport/service/TransportService.java
@@ -4,6 +4,7 @@ import com.network.sse.chat_message.domain.ChatMessage;
 import com.network.sse.transport.infrastructure.EmitterRepository;
 import java.io.IOException;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -11,7 +12,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Service
 @RequiredArgsConstructor
 public class TransportService {
-    private static final Long SSE_TIMEOUT = 1000 * 10L;
+    private static final Long SSE_TIMEOUT = 1000 * 20L;
     private final EmitterRepository emitterRepository;
 
     /**
@@ -44,6 +45,10 @@ public class TransportService {
             sendToClient(emitter, emitterId, "EventStream Created... [chatRoomId=%d userId=%d]".formatted(chatRoomId, userId));
         }
 
+        if (!lastEventId.isEmpty()) {
+            sendLostData(lastEventId, emitterIdPrefix, emitter);
+        }
+
         return emitter;
     }
 
@@ -66,6 +71,23 @@ public class TransportService {
     }
 
     /**
+     * 미수신 데이터 전송
+     * @param lastEventId 마지막으로 수신한 이벤트 id
+     * @param emitterIdPrefix SseEmitter id 접두사 (채팅방id_유저id)
+     * @param emitter SseEmitter 객체
+     */
+    private void sendLostData(String lastEventId, String emitterIdPrefix, SseEmitter emitter) {
+        Map<String, Object> events = emitterRepository.findAllEventCacheStartWithId(emitterIdPrefix);
+
+        events.entrySet().stream()
+                .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                .forEach(entry -> {
+                    ChatMessage chatMessage = (ChatMessage) entry.getValue();
+                    sendToClient(emitter, entry.getKey(), chatMessage.getContent());
+                });
+    }
+
+    /**
      * sse로 실시간 채팅 메시지 전송
      * @param chatRoomId 채팅방 id
      * @param receiverId 수신자 user id
@@ -78,11 +100,28 @@ public class TransportService {
 
         String eventId = emitterIdPrefix + "_" + System.currentTimeMillis();
 
+        // 데이터 유실에 대비해 캐시에 데이터 저장
+        emitterRepository.saveEventCache(eventId, chatMessage);
+
         sseEmitters.forEach(
                 (key, emitter) -> {
                     // 데이터 전송
                     sendToClient(emitter, eventId, chatMessage.getContent());
                 }
         );
+    }
+
+    /*모든 SseEmitter 조회*/
+    public Map<String, String> getAllEmitters() {
+        return emitterRepository.getAllEmitters().entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> entry.getValue().toString()
+                ));
+    }
+
+    /*모든 event cache 조회*/
+    public Map<String, Object> getAllEventCache() {
+        return emitterRepository.getAllEventCache();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #7 

## 📝 작업 내용

- SSE 연결이 끊어져 재연결을 시도하는 사이, 누군가 나에게 발송한 메시지를 유실하지 않고 정상적으로 수신하도록 구현했어요
    - 클라이언트가 끊긴 동안 전송된 데이터를 보존해야 하므로, 서버에서 데이터를 캐싱해요
    - 클라이언트는 재연결이 되자마자 미수신 데이터를 순서대로 받아요

### 스크린샷 (선택)

테스트 내용을 영상으로 찍어 첨부할게요
왼쪽 화면: User1(수신자) | 오른쪽 화면: User2(발신자)

https://github.com/user-attachments/assets/6012f3a6-53df-4572-a72f-15afd33708c2

## 💬 리뷰 요구사항(선택)