### PR TITLE
[고도화] 클라이언트가 정상적으로 연결을 끊었을 때, 서버 리소스 누수가 발생하지 않도록 처리하기 1 - 종료된 SseEmitter 삭제

### DIFF
--- a/src/main/java/com/network/sse/transport/infrastructure/EmitterRepository.java
+++ b/src/main/java/com/network/sse/transport/infrastructure/EmitterRepository.java
@@ -6,7 +6,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public interface EmitterRepository {
     SseEmitter save(String emitterId, SseEmitter sseEmitter);
     Map<String, SseEmitter> findAllEmitterStartWithId(String id);
-    void deleteById(String emitterId);
+    void deleteEmitterById(String emitterId);
     void saveEventCache(String eventCacheId, Object event);
     Map<String, Object> findAllEventCacheStartWithId(String id);
     void deleteEventCacheById(String eventCacheId);

--- a/src/main/java/com/network/sse/transport/infrastructure/EmitterRepositoryImpl.java
+++ b/src/main/java/com/network/sse/transport/infrastructure/EmitterRepositoryImpl.java
@@ -25,7 +25,7 @@ public class EmitterRepositoryImpl implements EmitterRepository {
     }
 
     @Override
-    public void deleteById(String emitterId) {
+    public void deleteEmitterById(String emitterId) {
         emitters.remove(emitterId);
     }
 

--- a/src/main/java/com/network/sse/transport/service/TransportService.java
+++ b/src/main/java/com/network/sse/transport/service/TransportService.java
@@ -14,7 +14,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequiredArgsConstructor
 @Slf4j
 public class TransportService {
-    private static final Long SSE_TIMEOUT = 1000 * 5L;
+    private static final Long SSE_TIMEOUT = 1000 * 20L;
     private final EmitterRepository emitterRepository;
 
     /**


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #9 

## 📝 작업 내용

- 클라이언트 연결 종료 이벤트를 서버가 감지하도록 구현했어요
    - 특정 상황에 콜백을 등록하는 ResponseBodyEmitter의 세 가지 메서드를 활용했어요
    <img width="530" alt="image" src="https://github.com/user-attachments/assets/89b87fe4-5d96-4dae-a4a6-047b6e6aab8c" />
- 클라이언트가 연결을 끊었을 때, 종료된 SseEmitter를 메모리에서 삭제해요

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
